### PR TITLE
Curl dns resolution name issue on servers with ipv6

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,21 @@ if ($answerObject->status == 'success') {
 ```
 
 All other examples you can see in the "[examples](https://github.com/zadarma/user-api-v1/tree/master/examples)" folder.
+
+###  \Zadarma_API\Client call with ip dns resolution preferences
+On servers with ipv6 can be an issue the curl dns resolution, you can set the preference on dns resolution 
+```php
+<?php
+$params = array(
+    'id' => 'YOURSIP',
+    'status' => 'on'
+);
+
+$zd = new \Zadarma_API\Client(YOUR_KEY, YOUR_SECRET);
+/**
+ * $zd->setIpv4Preference() //prefer ipv4 
+ * $zd->setIpv6Preference() //prefer ipv6 
+ * $zd->setIpAllPreference() //prefer both ipv4 and ipv6 (default behavior) 
+ */
+
+```

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -13,6 +13,7 @@ class Client
     private $secret;
     private $httpCode;
     private $limits = array();
+    private $ipPreferences = CURL_IPRESOLVE_WHATEVER;
 
     /**
      * @param $key
@@ -57,6 +58,7 @@ class Client
             CURLOPT_SSL_VERIFYHOST => false,
             CURLOPT_HEADERFUNCTION => array($this, 'parseHeaders'),
             CURLOPT_HTTPHEADER     => $this->getAuthHeader($method, $params),
+            CURLOPT_IPRESOLVE => $this->ipPreferences
         );
 
         $ch = curl_init();
@@ -102,6 +104,33 @@ class Client
     public function getLimits()
     {
         return $this->limits;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setIpv4Preference()
+    {
+        $this->ipPreferences = CURL_IPRESOLVE_V4;
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setIpv6Preference()
+    {
+        $this->ipPreferences = CURL_IPRESOLVE_V6;
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setIpAllPreference()
+    {
+        $this->ipPreferences = CURL_IPRESOLVE_WHATEVER;
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Issue on servers with ipv6 related to timeouts try to resolve api.zadarma.com on Ipv6, the developer can now set the preference on which ip protocol use for dns resolution. 

To avoid breaking things, the default behavior still is CURL_IPRESOLVE_WHATEVER, but some setters has been added to allow change to ipv4 or ipv6 (for future)

- fix issue related to ipv6 dns resolution
- added feature: set curl ip protocol dns resolution preference